### PR TITLE
Do numerical sort on Visual Studio version numbers

### DIFF
--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -1236,7 +1236,7 @@ def get_visualstudio_versions():
     except ValueError:
         pass
 
-    L.sort()
+    L.sort(lambda x, y: int(x.split('.')[0]) - int(y.split('.')[0]))
     L.reverse()
 
     return L


### PR DESCRIPTION
This way `12.0 > 1.0`.  Didn't work before as `1.0 > 12.0` lexicographically.
