### PR TITLE
Adding logic to use PowerShell when available and necessary

### DIFF
--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -516,7 +516,7 @@ class CommandAction(_ActionAction):
                             shell = powershell_path
                             break
             except:
-                pass
+                pass # don't do anything (and don't alter the 'pre-patch' behavior)
             finally:
                 if psc_key != None:
                     wreg.CloseKey(psc_key)

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -505,7 +505,7 @@ class CommandAction(_ActionAction):
                 if '%systemroot%' in raw_path:
                     powershell_path = string.replace(raw_path, '%systemroot%', os.getenv('systemroot'))
 
-                if os.path.isfile(powershell_path) == True:
+                if os.path.isfile(powershell_path):
                     maxline -= (len(cmd_line) - 1) # account for command line whitespace
                     for item in cmd_line:
                         maxline -= len(item)

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -480,7 +480,7 @@ class CommandAction(_ActionAction):
         # DLADD: JRH 20151022 SF37871/SF37872: DLE now contains to many .java and .cs files
         #                                      to compile with the standard windows cmd.exe
         # on windows, use powershell when available/necessary (to avoid command line length limit failures)
-        if sys.platform == 'win32':
+        if (sys.platform == 'win32') and (cmd_line[0] == 'javac'):
             try:
                 maxline = int(env.subst('$MAXLINELENGTH'))
             except ValueError:

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -487,12 +487,18 @@ class CommandAction(_ActionAction):
                 maxline = 2048
 
             psc_key = None
+            psc_value = None
             try:
                 import _winreg as wreg
-
                 psc_key = wreg.OpenKey(wreg.HKEY_CLASSES_ROOT, 'Microsoft.PowerShellConsole.1')
                 psc_value = wreg.QueryValueEx(psc_key, 'FriendlyTypeName')
+            except:
+                pass # don't do anything (and don't alter the 'pre-patch' behavior)
+            finally:
+                if psc_key != None:
+                    wreg.CloseKey(psc_key)
 
+            if psc_value != None:
                 # the parse logic (below) might be a bit sketchy since it implies a schema
                 # for the registry key. if that schema should change, this logic will fail
                 # to tease the path out of the registry key's raw value. at present, the
@@ -515,11 +521,6 @@ class CommandAction(_ActionAction):
                             # so, use powershell instead...
                             shell = powershell_path
                             break
-            except:
-                pass # don't do anything (and don't alter the 'pre-patch' behavior)
-            finally:
-                if psc_key != None:
-                    wreg.CloseKey(psc_key)
 
         # Use len() to filter out any "command" that's zero-length.
         for cmd_line in filter(len, cmd_list):


### PR DESCRIPTION
...to avoid command line length limits in Windows. This repairs
a fatal build error in DLE.